### PR TITLE
Plugin vim-tmux-navigator

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -43,6 +43,7 @@ if has('signs')
     let g:gitgutter_eager = 0         " Don't run eagerly
 endif
 " End gitgutter
+Plugin 'christoomey/vim-tmux-navigator'
 
 " All of your Plugins must be added before the following line
 call vundle#end()            " required
@@ -99,12 +100,12 @@ nnoremap <S-u> :red <CR> " redo
 map <F2> :NERDTreeToggle<CR>
 map <F3> :NERDTreeFind<CR>    " locates the file in the tree
 " mapping move line
-nnoremap <C-k> :m .-2<CR>==
-nnoremap <C-j> :m .+1<CR>==
-inoremap <C-j> <Esc>:m .+1<CR>==gi
-inoremap <C-k> <Esc>:m .-2<CR>==gi
-vnoremap <C-j> :m '>+1<CR>gv=gv
-vnoremap <C-k> :m '<-2<CR>gv=gv
+nnoremap <S-k> :m .-2<CR>==
+nnoremap <S-j> :m .+1<CR>==
+inoremap <S-j> <Esc>:m .+1<CR>==gi
+inoremap <S-k> <Esc>:m .-2<CR>==gi
+vnoremap <S-j> :m '>+1<CR>gv=gv
+vnoremap <S-k> :m '<-2<CR>gv=gv
 " mapping save
 :inoremap <c-s> <Esc>:update<CR>
 :inoremap <c-s> <c-o>:update<CR>


### PR DESCRIPTION
- Add plugin vim-tmux-navigator.
- Change move line to key Shift + j or k.
# Configuration tmux.conf

```
# Smart pane switching with awareness of vim splits
is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?)(diff)?$"'
bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
bind -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
bind -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
bind -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
```
