### PR TITLE
Add EditorConfig plugin

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -18,7 +18,7 @@ call vundle#begin()
 
 " let Vundle manage Vundle, required
 Plugin 'gmarik/Vundle.vim'
-
+Plugin 'editorconfig/editorconfig-vim'
 " Keep Plugin commands between vundle#begin/end.
 " plugin on GitHub repo
 Plugin 'tpope/vim-fugitive'


### PR DESCRIPTION
## Supported properties

The EditorConfig Vim plugin supports the following EditorConfig [properties][]:
- `indent_style`
- `indent_size`
- `tab_width`
- `end_of_line`
- `charset`
- `insert_final_newline` (Feature +fixendofline (available on Vim 7.4.785+) or [PreserveNoEOL][] is required for this property)
- `trim_trailing_whitespace`
- `max_line_length`
- `root` (only used by EditorConfig core)
